### PR TITLE
Add Enum support

### DIFF
--- a/src/autofaker/enums.py
+++ b/src/autofaker/enums.py
@@ -8,8 +8,7 @@ def is_enum(t) -> bool:
 
 
 class EnumGenerator(TypeDataGeneratorBase):
-    def __init__(self, enum, use_fake_data: bool = False):
-        self.use_fake_data = use_fake_data
+    def __init__(self, enum):
         self.enum = enum
 
     def generate(self):

--- a/src/autofaker/enums.py
+++ b/src/autofaker/enums.py
@@ -1,0 +1,18 @@
+import random
+
+from autofaker.base import TypeDataGeneratorBase
+
+
+def is_enum(t) -> bool:
+    return t.__base__.__name__.lower() == 'enum'
+
+
+class EnumGenerator(TypeDataGeneratorBase):
+    def __init__(self, enum, use_fake_data: bool = False):
+        self.use_fake_data = use_fake_data
+        self.enum = enum
+
+    def generate(self):
+        names = [member.name for member in self.enum]
+        value = names[random.randint(0, len(self.enum) - 1)]
+        return self.enum[value]

--- a/src/autofaker/enums.py
+++ b/src/autofaker/enums.py
@@ -4,7 +4,7 @@ from autofaker.base import TypeDataGeneratorBase
 
 
 def is_enum(t) -> bool:
-    return t.__base__.__name__.lower() == 'enum'
+    return t.__base__.__name__ == 'Enum'
 
 
 class EnumGenerator(TypeDataGeneratorBase):

--- a/src/autofaker/generator.py
+++ b/src/autofaker/generator.py
@@ -21,7 +21,7 @@ class TypeDataGenerator:
         if type_name == 'list':
             return ListGenerator(t)
         if is_enum(t):
-            return EnumGenerator(t, use_fake_data)
+            return EnumGenerator(t)
         return DataClassGenerator(t, use_fake_data=use_fake_data) \
             if dataclasses.is_dataclass(t) \
             else ClassGenerator(t, use_fake_data=use_fake_data)

--- a/src/autofaker/generator.py
+++ b/src/autofaker/generator.py
@@ -7,6 +7,7 @@ from autofaker.attributes import Attributes
 from autofaker.dates import DatetimeGenerator, DateGenerator, is_date_type
 from autofaker.factory import BuiltinTypeDataGeneratorFactory
 from autofaker.fakes import TypeDataGeneratorBase
+from autofaker.enums import EnumGenerator, is_enum
 
 
 class TypeDataGenerator:
@@ -19,6 +20,8 @@ class TypeDataGenerator:
             return TypeDataGenerator.create_datetime(type_name, field_name, use_fake_data)
         if type_name == 'list':
             return ListGenerator(t)
+        if is_enum(t):
+            return EnumGenerator(t, use_fake_data)
         return DataClassGenerator(t, use_fake_data=use_fake_data) \
             if dataclasses.is_dataclass(t) \
             else ClassGenerator(t, use_fake_data=use_fake_data)

--- a/tests/pytests/test_decorator_anonymous_enum_classes.py
+++ b/tests/pytests/test_decorator_anonymous_enum_classes.py
@@ -1,0 +1,23 @@
+from enum import Enum
+
+from autofaker import autodata
+
+
+class Weekday(Enum):
+    MONDAY = 1
+    TUESDAY = 2
+    WEDNESDAY = 3
+    THURSDAY = 4
+    FRIDAY = 5
+    SATURDAY = 6
+    SUNDAY = 7
+
+
+@autodata(Weekday)
+def test_create_enum_class_returns_not_none(sut):
+    assert sut is not None
+
+
+@autodata(Weekday)
+def test_create_enum_class_returns_instance(sut):
+    assert isinstance(sut, Weekday)

--- a/tests/test_create_anonymous_enum_classes.py
+++ b/tests/test_create_anonymous_enum_classes.py
@@ -1,0 +1,23 @@
+import unittest
+from enum import Enum
+
+from autofaker import Autodata
+
+
+class Weekday(Enum):
+    MONDAY = 1
+    TUESDAY = 2
+    WEDNESDAY = 3
+    THURSDAY = 4
+    FRIDAY = 5
+    SATURDAY = 6
+    SUNDAY = 7
+
+
+class AnonymousWeekdayTestCase(unittest.TestCase):
+
+    def test_create_enum_class_returns_not_none(self):
+        self.assertIsNotNone(Autodata.create(Weekday))
+
+    def test_create_enum_class_returns_instance(self):
+        self.assertIsInstance(Autodata.create(Weekday), Weekday)

--- a/tests/unittests/test_decorator_anonymous_enum_classes.py
+++ b/tests/unittests/test_decorator_anonymous_enum_classes.py
@@ -1,0 +1,25 @@
+import unittest
+from enum import Enum
+
+from autofaker import autodata
+
+
+class Weekday(Enum):
+    MONDAY = 1
+    TUESDAY = 2
+    WEDNESDAY = 3
+    THURSDAY = 4
+    FRIDAY = 5
+    SATURDAY = 6
+    SUNDAY = 7
+
+
+class AnonymousWeekdayTestCase(unittest.TestCase):
+
+    @autodata(Weekday)
+    def test_create_enum_class_returns_not_none(self, sut):
+        self.assertIsNotNone(sut)
+
+    @autodata(Weekday)
+    def test_create_enum_class_returns_instance(self, sut):
+        self.assertIsInstance(sut, Weekday)


### PR DESCRIPTION
This implements #6

Example usage:

```python
from enum import Enum

class Weekday(Enum):
    MONDAY = 1
    TUESDAY = 2
    WEDNESDAY = 3
    THURSDAY = 4
    FRIDAY = 5
    SATURDAY = 6
    SUNDAY = 7
```

```python
from autofaker import autodata

@autodata(Weekday)
def test_create_enum_class_returns_not_none(sut):
    assert sut is not None

@autodata(Weekday)
def test_create_enum_class_returns_instance(sut):
    assert isinstance(sut, Weekday)
```

```python
import unittest
from autofaker import Autodata

class AnonymousWeekdayTestCase(unittest.TestCase):

    def test_create_enum_class_returns_not_none(self):
        self.assertIsNotNone(Autodata.create(Weekday))

    def test_create_enum_class_returns_instance(self):
        self.assertIsInstance(Autodata.create(Weekday), Weekday)
```