### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/build-for-os.yml
+++ b/.github/workflows/build-for-os.yml
@@ -20,6 +20,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/build-python-312-linux.yml
+++ b/.github/workflows/build-python-312-linux.yml
@@ -6,7 +6,7 @@ on:
       - src/**/*.py
       - tests/**/*.py
       - .github/workflows/build.yml
-      - .github/workflows/build-python-311-linux.yml
+      - .github/workflows/build-python-312-linux.yml
   workflow_dispatch:
   pull_request:
     types:

--- a/.github/workflows/build-python-312-macos.yml
+++ b/.github/workflows/build-python-312-macos.yml
@@ -6,7 +6,7 @@ on:
       - src/**/*.py
       - tests/**/*.py
       - .github/workflows/build.yml
-      - .github/workflows/build-python-311-macos.yml
+      - .github/workflows/build-python-312-macos.yml
   workflow_dispatch:
   pull_request:
     types:

--- a/.github/workflows/build-python-312-windows.yml
+++ b/.github/workflows/build-python-312-windows.yml
@@ -6,7 +6,7 @@ on:
       - src/**/*.py
       - tests/**/*.py
       - .github/workflows/build.yml
-      - .github/workflows/build-python-311-windows.yml
+      - .github/workflows/build-python-312-windows.yml
   workflow_dispatch:
   pull_request:
     types:

--- a/.github/workflows/build-python-313-linux.yml
+++ b/.github/workflows/build-python-313-linux.yml
@@ -1,0 +1,22 @@
+name: 3.13
+
+on:
+  push:
+    paths:
+      - src/**/*.py
+      - tests/**/*.py
+      - .github/workflows/build.yml
+      - .github/workflows/build-python-313-linux.yml
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      python_version: 3.13
+      os: ubuntu-latest3

--- a/.github/workflows/build-python-313-macos.yml
+++ b/.github/workflows/build-python-313-macos.yml
@@ -1,0 +1,22 @@
+name: 3.13
+
+on:
+  push:
+    paths:
+      - src/**/*.py
+      - tests/**/*.py
+      - .github/workflows/build.yml
+      - .github/workflows/build-python-313-macos.yml
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      python_version: 3.13
+      os: macos-latest

--- a/.github/workflows/build-python-313-windows.yml
+++ b/.github/workflows/build-python-313-windows.yml
@@ -1,0 +1,22 @@
+name: 3.13
+
+on:
+  push:
+    paths:
+      - src/**/*.py
+      - tests/**/*.py
+      - .github/workflows/build.yml
+      - .github/workflows/build-python-313-windows.yml
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      python_version: 3.13
+      os: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ job:    Chief Operating Officer
 ![](https://github.com/christianhelle/autofaker/actions/workflows/build-python-310-windows.yml/badge.svg)|![](https://github.com/christianhelle/autofaker/actions/workflows/build-python-310-macos.yml/badge.svg)|![](https://github.com/christianhelle/autofaker/actions/workflows/build-python-310-linux.yml/badge.svg)|
 ![](https://github.com/christianhelle/autofaker/actions/workflows/build-python-311-windows.yml/badge.svg)|![](https://github.com/christianhelle/autofaker/actions/workflows/build-python-311-macos.yml/badge.svg)|![](https://github.com/christianhelle/autofaker/actions/workflows/build-python-311-linux.yml/badge.svg)|
 ![](https://github.com/christianhelle/autofaker/actions/workflows/build-python-312-windows.yml/badge.svg)|![](https://github.com/christianhelle/autofaker/actions/workflows/build-python-312-macos.yml/badge.svg)|![](https://github.com/christianhelle/autofaker/actions/workflows/build-python-312-linux.yml/badge.svg)|
+![](https://github.com/christianhelle/autofaker/actions/workflows/build-python-313-windows.yml/badge.svg)|![](https://github.com/christianhelle/autofaker/actions/workflows/build-python-313-macos.yml/badge.svg)|![](https://github.com/christianhelle/autofaker/actions/workflows/build-python-313-linux.yml/badge.svg)|
 
 ## Supported data types
 


### PR DESCRIPTION
This pull request updates the Python version to 3.13 in the build and test workflows. It includes the following changes:

- Fix ignore paths

- Add build workflows for Python 3.13 on different platforms

- Add build badges for Python 3.13